### PR TITLE
Delegate export/import via renderer with modal prompts

### DIFF
--- a/main/menu.ts
+++ b/main/menu.ts
@@ -21,16 +21,24 @@ export const createApplicationMenu = (): Menu => {
           label: 'データをエクスポート',
           accelerator: 'CmdOrCtrl+E',
           click: () => {
-            // Will be implemented in task 12
-            console.log('Export data clicked')
+            const focusedWindow = BrowserWindow.getFocusedWindow()
+            if (focusedWindow) {
+              focusedWindow.webContents.send('data:export-request')
+            } else {
+              console.error('[Menu] No focused window found for export')
+            }
           }
         },
         {
           label: 'データをインポート',
           accelerator: 'CmdOrCtrl+I',
           click: () => {
-            // Will be implemented in task 13
-            console.log('Import data clicked')
+            const focusedWindow = BrowserWindow.getFocusedWindow()
+            if (focusedWindow) {
+              focusedWindow.webContents.send('data:import-request')
+            } else {
+              console.error('[Menu] No focused window found for import')
+            }
           }
         },
         { type: 'separator' },

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -36,6 +36,8 @@ const IPC_EVENTS = {
   // Data Management
   DATA_EXPORT: 'data:export',
   DATA_IMPORT: 'data:import',
+  DATA_EXPORT_REQUEST: 'data:export-request',
+  DATA_IMPORT_REQUEST: 'data:import-request',
   
   // Settings
   SETTINGS_GET: 'settings:get',
@@ -97,6 +99,12 @@ const electronAPI = {
   // Export/Import
   exportData: createSecureInvoker(IPC_EVENTS.DATA_EXPORT),
   importData: createSecureInvoker(IPC_EVENTS.DATA_IMPORT),
+  onDataExportRequest: (callback: () => void) => {
+    ipcRenderer.on(IPC_EVENTS.DATA_EXPORT_REQUEST, () => callback())
+  },
+  onDataImportRequest: (callback: () => void) => {
+    ipcRenderer.on(IPC_EVENTS.DATA_IMPORT_REQUEST, () => callback())
+  },
   
   // Print
   printReceipt: createSecureInvoker(IPC_EVENTS.PRINT_RECEIPT),

--- a/src/services/electronAPI.ts
+++ b/src/services/electronAPI.ts
@@ -2,6 +2,10 @@
 import { ApiResponse, Category, Task, CreateInput, PartialUpdate } from '../types'
 
 class ElectronAPIService {
+  constructor() {
+    this.setupDataHandlers()
+  }
+
   private checkElectronAPI(): void {
     if (!window.electronAPI) {
       throw new Error('Electron API is not available. Make sure the app is running in Electron environment.')
@@ -138,6 +142,70 @@ class ElectronAPIService {
       () => window.electronAPI.exportData(),
       'データエクスポート'
     )
+  }
+
+  async importData(backupData: string): Promise<ApiResponse<void>> {
+    return this.handleAPICall(
+      () => window.electronAPI.importData(backupData),
+      'データインポート'
+    )
+  }
+
+  private setupDataHandlers(): void {
+    if (!window.electronAPI?.onDataExportRequest || !window.electronAPI?.onDataImportRequest) {
+      return
+    }
+
+    window.electronAPI.onDataExportRequest(async () => {
+      const confirmed = window.confirm('現在のデータをエクスポートしますか？')
+      if (!confirmed) return
+
+      try {
+        const result = await this.exportData()
+        if (result.success && result.data) {
+          const blob = new Blob([result.data], { type: 'application/json' })
+          const url = URL.createObjectURL(blob)
+          const a = document.createElement('a')
+          a.href = url
+          a.download = `backup-${new Date().toISOString().split('T')[0]}.json`
+          a.click()
+          URL.revokeObjectURL(url)
+          alert('エクスポートが完了しました')
+        } else {
+          alert(`エクスポートに失敗しました: ${result.error ?? '不明なエラー'}`)
+        }
+      } catch (error) {
+        console.error('Export failed:', error)
+        alert('エクスポート中にエラーが発生しました')
+      }
+    })
+
+    window.electronAPI.onDataImportRequest(async () => {
+      const input = document.createElement('input')
+      input.type = 'file'
+      input.accept = 'application/json'
+      input.onchange = async () => {
+        const file = input.files?.[0]
+        if (!file) return
+
+        const text = await file.text()
+        const confirmImport = window.confirm('選択したデータをインポートすると現在のデータが上書きされます。続行しますか？')
+        if (!confirmImport) return
+
+        try {
+          const result = await this.importData(text)
+          if (result.success) {
+            alert('インポートが完了しました')
+          } else {
+            alert(`インポートに失敗しました: ${result.error ?? '不明なエラー'}`)
+          }
+        } catch (error) {
+          console.error('Import failed:', error)
+          alert('インポート中にエラーが発生しました')
+        }
+      }
+      input.click()
+    })
   }
 
   // Utility methods

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -61,6 +61,8 @@ export interface ElectronAPI {
   // Export/Import
   exportData: () => Promise<ApiResponse<string>> // JSON string
   importData: (backupData: string) => Promise<ApiResponse<void>>
+  onDataExportRequest: (callback: () => void) => void
+  onDataImportRequest: (callback: () => void) => void
   
   // Print
   printReceipt: (data: PrintData) => Promise<ApiResponse<void>>
@@ -107,6 +109,8 @@ export interface IPCEventMap {
   // Data management
   'data:export': () => Promise<ApiResponse<string>>
   'data:import': (data: string) => Promise<ApiResponse<void>>
+  'data:export-request': () => void
+  'data:import-request': () => void
   
   // Print
   'print:receipt': (data: PrintData) => Promise<ApiResponse<void>>


### PR DESCRIPTION
## Summary
- Route export/import menu items through renderer via IPC messages
- Expose export/import request listeners in preload and handle them in ElectronAPI service with dialogs
- Support data import flow including file selection and confirmation prompt

## Testing
- `npm run lint` *(fails: ESLint couldn't find the config "@typescript-eslint/recommended" to extend from)*
- `npm run type-check` *(fails: Module '../types' has no exported member 'ValidationError', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d1bd6a508320bc7e41927f6945ce