### PR TITLE
Remove obsolete test navigation

### DIFF
--- a/main/menu.ts
+++ b/main/menu.ts
@@ -1,4 +1,4 @@
-import { Menu, MenuItemConstructorOptions, shell, BrowserWindow } from 'electron'
+import { Menu, MenuItemConstructorOptions, BrowserWindow } from 'electron'
 import { getAppVersion } from './utils'
 
 export const createApplicationMenu = (): Menu => {
@@ -58,19 +58,6 @@ export const createApplicationMenu = (): Menu => {
           label: 'ホーム',
           accelerator: 'CmdOrCtrl+H',
           click: () => navigateToPage('/')
-        },
-        {
-          label: 'テスト - アラート表示',
-          click: () => {
-            console.log('[Menu] Test alert clicked')
-            const focusedWindow = BrowserWindow.getFocusedWindow()
-            if (focusedWindow) {
-              focusedWindow.webContents.executeJavaScript(`
-                alert('メニューからのテスト実行が成功しました！');
-                console.log('[Renderer] Test alert executed');
-              `)
-            }
-          }
         },
         { type: 'separator' },
         {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -20,45 +20,6 @@ const HomePage: React.FC = () => {
           <Navigation />
         </div>
         
-        {/* テスト用ナビゲーションボタン */}
-        <div className="mt-8 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
-          <h3 className="text-lg font-bold text-yellow-800 mb-4">🧪 テスト用ナビゲーション</h3>
-          <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-            <button
-              onClick={() => {
-                console.log('[HomePage] Test button clicked - Task Management')
-                window.location.hash = '#/task-management'
-              }}
-              className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm"
-            >
-              タスク管理 (Hash)
-            </button>
-            <button
-              onClick={() => {
-                console.log('[HomePage] Test button clicked - Daily Input')
-                window.history.pushState({}, '', '/daily-input')
-                window.dispatchEvent(new PopStateEvent('popstate'))
-              }}
-              className="px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600 text-sm"
-            >
-              タスク入力 (History)
-            </button>
-            <button
-              onClick={() => {
-                console.log('[HomePage] Test button clicked - Calculation')
-                if (window.electronAPI && window.electronAPI.navigateTo) {
-                  window.electronAPI.navigateTo('/calculation')
-                } else {
-                  console.error('electronAPI.navigateTo not available')
-                }
-              }}
-              className="px-4 py-2 bg-purple-500 text-white rounded hover:bg-purple-600 text-sm"
-            >
-              計算 (IPC)
-            </button>
-          </div>
-        </div>
-        
         <div className="mt-8 text-center">
           <div className="inline-flex items-center space-x-4 text-sm text-gray-500 bg-white rounded-full px-4 py-2 shadow-sm">
             <div className="flex items-center space-x-2">
@@ -75,3 +36,4 @@ const HomePage: React.FC = () => {
 }
 
 export default HomePage
+


### PR DESCRIPTION
## Summary
- drop leftover test alert entry from the Electron menu
- remove temporary test navigation buttons from the home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find the config "@typescript-eslint/recommended")*
- `npm run type-check` *(fails: Module '../types' has no exported member 'ValidationError', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d9256774832098cc5da503277f46