### PR TITLE
Fix printing always reported as cancelled

### DIFF
--- a/main/ipc-handlers.ts
+++ b/main/ipc-handlers.ts
@@ -1021,13 +1021,16 @@ export const setupIpcHandlers = (): void => {
       
       // 印刷実行をラップして結果を判定
       await new Promise<void>((resolve, reject) => {
-        printWindow.webContents.print(printOptions, (success, failureReason) => {
-          if (success) {
-            resolve()
-          } else {
-            reject(new Error(failureReason || '印刷がキャンセルされました'))
+        printWindow.webContents.print(
+          printOptions,
+          (success: boolean, failureReason?: string) => {
+            if (success) {
+              resolve()
+            } else {
+              reject(new Error(failureReason || '印刷がキャンセルされました'))
+            }
           }
-        })
+        )
       })
 
       // 印刷ウィンドウを閉じる

--- a/main/ipc-handlers.ts
+++ b/main/ipc-handlers.ts
@@ -1020,23 +1020,19 @@ export const setupIpcHandlers = (): void => {
       }
       
       // 印刷実行
-      const result = await printWindow.webContents.print(printOptions)
-      
+      await printWindow.webContents.print(printOptions)
+
       // 印刷ウィンドウを閉じる
       printWindow.close()
-      
+
       // 一時ファイルを削除
       try {
         fs.unlinkSync(tempFilePath)
       } catch (cleanupError) {
         console.warn('Failed to cleanup temp file:', cleanupError)
       }
-      
-      if (result) {
-        return { success: true }
-      } else {
-        return { success: false, error: '印刷がキャンセルされました' }
-      }
+
+      return { success: true }
     } catch (error) {
       console.error('Failed to print receipt:', error)
       return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }

--- a/main/ipc-handlers.ts
+++ b/main/ipc-handlers.ts
@@ -972,7 +972,7 @@ export const setupIpcHandlers = (): void => {
   // Print operations
   ipcMain.handle('print:receipt', async (event, printData) => {
     try {
-      const { BrowserWindow, dialog } = require('electron')
+      const { BrowserWindow } = require('electron')
       const path = require('path')
       const fs = require('fs')
       
@@ -1003,7 +1003,7 @@ export const setupIpcHandlers = (): void => {
         silent: false,
         printBackground: true,
         color: true,
-        margin: {
+        margins: {
           marginType: 'custom',
           top: printData.options.margins.top,
           bottom: printData.options.margins.bottom,
@@ -1019,8 +1019,16 @@ export const setupIpcHandlers = (): void => {
         footer: ''
       }
       
-      // 印刷実行
-      await printWindow.webContents.print(printOptions)
+      // 印刷実行をラップして結果を判定
+      await new Promise<void>((resolve, reject) => {
+        printWindow.webContents.print(printOptions, (success, failureReason) => {
+          if (success) {
+            resolve()
+          } else {
+            reject(new Error(failureReason || '印刷がキャンセルされました'))
+          }
+        })
+      })
 
       // 印刷ウィンドウを閉じる
       printWindow.close()


### PR DESCRIPTION
## Summary
- Print handler now treats successful print operations as success instead of cancellation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find the config "@typescript-eslint/recommended")*
- `npm run type-check` *(fails: TS6133: 'React' is declared but its value is never read)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fe8c110883208d99d62216fb4970