### PR TITLE
Increase print preview margins

### DIFF
--- a/main/ipc-handlers.ts
+++ b/main/ipc-handlers.ts
@@ -169,6 +169,13 @@ const generatePrintHTML = (printData: any): string => {
           color: #000;
           background: white;
         }
+
+        @media screen {
+          body {
+            padding: 40px;
+            background: #f9fafb;
+          }
+        }
         
         .print-layout {
           width: 100%;

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -161,7 +161,7 @@
   border: 1px solid #d1d5db;
   border-radius: 8px;
   background: #f9fafb;
-  padding: 20px;
+  padding: 40px;
 }
 
 .print-preview .print-layout {


### PR DESCRIPTION
## Summary
- add screen-only padding to print HTML for more space in preview
- enlarge padding around React print preview container

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find config "@typescript-eslint/recommended" to extend from)*
- `npm run type-check` *(fails: TypeScript errors in various files)*

------
https://chatgpt.com/codex/tasks/task_e_68a70604d12c8320a66d6f832e5ea02c