### PR TITLE
fix: refine print layout

### DIFF
--- a/main/ipc-handlers.ts
+++ b/main/ipc-handlers.ts
@@ -19,7 +19,7 @@ import { taskExecutionHelpers } from './database-helpers'
 
 // 印刷用HTML生成関数
 const generatePrintHTML = (printData: any): string => {
-  const { title, date, childName, data, options } = printData
+  const { title, date, data, options } = printData
   
   // 日付フォーマット
   const formatDate = (dateStr: string) => {
@@ -82,12 +82,9 @@ const generatePrintHTML = (printData: any): string => {
           ${data.taskDetails.map((task: any) => `
             <tr>
               <td>
-                <div>
+                <div style="display: flex; align-items: center; gap: 2mm;">
                   <span>${task.categoryIcon}</span>
-                  <div>
-                    <div class="font-medium">${task.taskName}</div>
-                    <div class="text-small text-gray">${task.categoryName}</div>
-                  </div>
+                  <span class="font-medium">${task.taskName}</span>
                 </div>
               </td>
               <td class="text-center">${task.count}回</td>
@@ -111,7 +108,6 @@ const generatePrintHTML = (printData: any): string => {
           <tr class="font-bold">
             <td colspan="${options.includeAdjustments ? 5 : 3}">合計</td>
             <td class="text-right text-large">${formatAmount(data.totalAmount)}</td>
-            ${options.includeAdjustments ? '<td></td>' : ''}
           </tr>
         </tfoot>
       </table>
@@ -275,24 +271,7 @@ const generatePrintHTML = (printData: any): string => {
         .adjustment-reasons {
           font-size: 10pt;
         }
-        
-        .signature-section {
-          margin-top: 12mm;
-          display: grid;
-          grid-template-columns: 1fr 1fr;
-          gap: 8mm;
-        }
-        
-        .signature-box {
-          text-align: center;
-        }
-        
-        .signature-line {
-          border-bottom: 1pt solid #333;
-          height: 8mm;
-          margin-bottom: 2mm;
-        }
-        
+
         .print-footer {
           border-top: 1pt solid #333;
           padding-top: 4mm;
@@ -313,9 +292,6 @@ const generatePrintHTML = (printData: any): string => {
               <div>発行日: ${new Date().toLocaleDateString('ja-JP')}</div>
             </div>
             <div class="text-right">
-              <div style="font-size: 14pt; font-weight: 500; margin-bottom: 1mm;">
-                ${childName} さん
-              </div>
               <div>対象日: ${formatDate(date)}</div>
             </div>
           </div>
@@ -338,18 +314,6 @@ const generatePrintHTML = (printData: any): string => {
         ${categoryTable}
         ${taskTable}
         ${adjustmentSummary}
-
-        <!-- 署名欄 -->
-        <div class="signature-section">
-          <div class="signature-box">
-            <div class="signature-line"></div>
-            <div>お子様サイン</div>
-          </div>
-          <div class="signature-box">
-            <div class="signature-line"></div>
-            <div>保護者サイン</div>
-          </div>
-        </div>
 
         <!-- フッター -->
         <div class="print-footer">


### PR DESCRIPTION
## Summary
- remove child name from print receipt header
- streamline task details row and totals
- delete unused signature section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find the config "@typescript-eslint/recommended")*

------
https://chatgpt.com/codex/tasks/task_e_68a708578f348320a5828fcd52596832