### PR TITLE
feat: open data directory from history page

### DIFF
--- a/main/ipc-handlers.ts
+++ b/main/ipc-handlers.ts
@@ -608,6 +608,18 @@ export const setupIpcHandlers = (): void => {
     }
   })
 
+  ipcMain.handle('data:open-directory', async () => {
+    try {
+      const { app, shell } = require('electron')
+      const userDataPath = app.getPath('userData')
+      await shell.openPath(userDataPath)
+      return { success: true }
+    } catch (error) {
+      console.error('Failed to open data directory:', error)
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }
+    }
+  })
+
   // Settings operations
   ipcMain.handle('settings:get', async (event, key) => {
     try {

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -38,6 +38,7 @@ const IPC_EVENTS = {
   DATA_IMPORT: 'data:import',
   DATA_EXPORT_REQUEST: 'data:export-request',
   DATA_IMPORT_REQUEST: 'data:import-request',
+  DATA_OPEN_DIR: 'data:open-directory',
   
   // Settings
   SETTINGS_GET: 'settings:get',
@@ -99,6 +100,7 @@ const electronAPI = {
   // Export/Import
   exportData: createSecureInvoker(IPC_EVENTS.DATA_EXPORT),
   importData: createSecureInvoker(IPC_EVENTS.DATA_IMPORT),
+  openDataDirectory: createSecureInvoker(IPC_EVENTS.DATA_OPEN_DIR),
   onDataExportRequest: (callback: () => void) => {
     ipcRenderer.on(IPC_EVENTS.DATA_EXPORT_REQUEST, () => callback())
   },

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -80,6 +80,14 @@ const HistoryPage: React.FC = () => {
     }
   }
 
+  const handleOpenDataDir = async () => {
+    try {
+      await electronAPI.openDataDirectory()
+    } catch (err) {
+      console.error('Failed to open data directory', err)
+    }
+  }
+
   const monthlyTotals = useMemo(() => {
     const result: Record<string, number> = {}
     stats?.trends?.forEach(t => {
@@ -133,6 +141,7 @@ const HistoryPage: React.FC = () => {
           </div>
           <button type="submit" className="btn-primary px-4 py-2">表示</button>
           <button type="button" onClick={handleExport} className="btn-secondary px-4 py-2">CSVエクスポート</button>
+          <button type="button" onClick={handleOpenDataDir} className="btn-secondary px-4 py-2">データ保存場所を開く</button>
         </div>
       </form>
 

--- a/src/services/electronAPI.ts
+++ b/src/services/electronAPI.ts
@@ -151,6 +151,13 @@ class ElectronAPIService {
     )
   }
 
+  async openDataDirectory(): Promise<ApiResponse<void>> {
+    return this.handleAPICall(
+      () => window.electronAPI.openDataDirectory(),
+      'データ保存場所を開く'
+    )
+  }
+
   private setupDataHandlers(): void {
     if (!window.electronAPI?.onDataExportRequest || !window.electronAPI?.onDataImportRequest) {
       return

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -61,6 +61,7 @@ export interface ElectronAPI {
   // Export/Import
   exportData: () => Promise<ApiResponse<string>> // JSON string
   importData: (backupData: string) => Promise<ApiResponse<void>>
+  openDataDirectory: () => Promise<ApiResponse<void>>
   onDataExportRequest: (callback: () => void) => void
   onDataImportRequest: (callback: () => void) => void
   
@@ -109,6 +110,7 @@ export interface IPCEventMap {
   // Data management
   'data:export': () => Promise<ApiResponse<string>>
   'data:import': (data: string) => Promise<ApiResponse<void>>
+  'data:open-directory': () => Promise<ApiResponse<void>>
   'data:export-request': () => void
   'data:import-request': () => void
   


### PR DESCRIPTION
## Summary
- allow users to open the data storage directory from the history page
- wire up IPC handler and preload bridge for opening the data folder

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find the config `@typescript-eslint/recommended`)*
- `npm run type-check` *(fails: Module '../types' has no exported member 'ValidationError')*


------
https://chatgpt.com/codex/tasks/task_e_68a70a8250b08320ac064a6f94cd7301