### PR TITLE
feat: split records by month

### DIFF
--- a/main/database-helpers.ts
+++ b/main/database-helpers.ts
@@ -140,7 +140,7 @@ export const taskHelpers = {
 export const dailyRecordHelpers = {
   // 日付で記録を取得
   getByDate: (date: string): DailyRecord | null => {
-    const records = getAllRecords<DailyRecord>('dailyRecords')
+    const records = getAllRecords<DailyRecord>('dailyRecords', { date })
     return records.find(record => record.date === date) || null
   },
 
@@ -169,19 +169,19 @@ export const dailyRecordHelpers = {
     }, 0)
     
     let dailyRecord: DailyRecord
-    
+
     if (existing) {
       // 既存記録を更新
       dailyRecord = updateRecord<DailyRecord>('dailyRecords', existing.id, {
         totalAmount,
         updatedAt: now
-      })!
-      
+      }, { date })!
+
       // 既存のタスク実行記録を削除
-      const allExecutions = getAllRecords<TaskExecution>('taskExecutions')
+      const allExecutions = getAllRecords<TaskExecution>('taskExecutions', { date })
       const executionsToDelete = allExecutions.filter(execution => execution.dailyRecordId === existing.id)
       for (const execution of executionsToDelete) {
-        deleteRecord('taskExecutions', execution.id)
+        deleteRecord('taskExecutions', execution.id, { date })
       }
     } else {
       // 新しい記録を作成
@@ -193,7 +193,7 @@ export const dailyRecordHelpers = {
         updatedAt: now
       })
     }
-    
+
     // タスク実行記録を保存
     for (const executionData of taskExecutions) {
       const execution: TaskExecution = {
@@ -201,7 +201,7 @@ export const dailyRecordHelpers = {
         dailyRecordId: dailyRecord.id,
         ...executionData
       }
-      createRecord('taskExecutions', execution)
+      createRecord('taskExecutions', execution, { date })
     }
     
     return dailyRecord
@@ -210,22 +210,25 @@ export const dailyRecordHelpers = {
   // 記録を削除
   delete: (id: string): boolean => {
     // 関連するタスク実行記録も削除
-    const taskExecutions = getAllRecords<TaskExecution>('taskExecutions')
+    const allRecords = getAllRecords<DailyRecord>('dailyRecords')
+    const record = allRecords.find(r => r.id === id)
+    if (!record) return false
+    const taskExecutions = getAllRecords<TaskExecution>('taskExecutions', { date: record.date })
     const executionsToDelete = taskExecutions.filter(execution => execution.dailyRecordId === id)
-    
+
     for (const execution of executionsToDelete) {
-      deleteRecord('taskExecutions', execution.id)
+      deleteRecord('taskExecutions', execution.id, { date: record.date })
     }
-    
-    return deleteRecord('dailyRecords', id)
+
+    return deleteRecord('dailyRecords', id, { date: record.date })
   }
 }
 
 // タスク実行記録関連のヘルパー関数
 export const taskExecutionHelpers = {
   // 日次記録IDで実行記録を取得
-  getByDailyRecordId: (dailyRecordId: string): TaskExecution[] => {
-    const executions = getAllRecords<TaskExecution>('taskExecutions')
+  getByDailyRecordId: (dailyRecordId: string, date?: string): TaskExecution[] => {
+    const executions = getAllRecords<TaskExecution>('taskExecutions', date ? { date } : undefined)
     return executions.filter(execution => execution.dailyRecordId === dailyRecordId)
   },
 
@@ -317,7 +320,7 @@ export const analyticsHelpers = {
       let totalCount = 0
       
       for (const record of records) {
-        const executions = taskExecutionHelpers.getByDailyRecordId(record.id)
+        const executions = taskExecutionHelpers.getByDailyRecordId(record.id, record.date)
         for (const execution of executions) {
           const task = categoryTasks.find(t => t.id === execution.taskId)
           if (task) {

--- a/main/database.ts
+++ b/main/database.ts
@@ -1,6 +1,9 @@
 import Store from 'electron-store'
 import { v4 as uuidv4 } from 'uuid'
 import { app } from 'electron'
+import path from 'path'
+import fs from 'fs'
+import { getMonthlyStore, listMonthlyFiles } from './monthly-store'
 
 // 型定義
 interface Category {
@@ -52,49 +55,38 @@ interface DatabaseSchema {
 type Stores = {
   categories: Store<Record<string, Category>>
   tasks: Store<Record<string, Task>>
-  dailyRecords: Store<Record<string, DailyRecord>>
-  taskExecutions: Store<Record<string, TaskExecution>>
   settings: Store<Record<string, string>>
   meta: Store<{ version: number }>
 }
 
-type DataStoreKey = keyof Pick<Stores, 'categories' | 'tasks' | 'dailyRecords' | 'taskExecutions'>
+type RegularStoreKey = keyof Pick<Stores, 'categories' | 'tasks'>
+type DataStoreKey = RegularStoreKey | 'dailyRecords' | 'taskExecutions'
 
 const stores: Partial<Stores> = {}
 
 export const setupDatabase = async (): Promise<void> => {
   try {
-    const userDataPath = app.getPath('userData')
+    userDataPath = app.getPath('userData')
 
     stores.categories = new Store<Record<string, Category>>({
       name: 'categories',
       cwd: userDataPath,
-      defaults: {}
+      defaults: {},
     })
     stores.tasks = new Store<Record<string, Task>>({
       name: 'tasks',
       cwd: userDataPath,
-      defaults: {}
-    })
-    stores.dailyRecords = new Store<Record<string, DailyRecord>>({
-      name: 'daily-records',
-      cwd: userDataPath,
-      defaults: {}
-    })
-    stores.taskExecutions = new Store<Record<string, TaskExecution>>({
-      name: 'task-executions',
-      cwd: userDataPath,
-      defaults: {}
+      defaults: {},
     })
     stores.settings = new Store<Record<string, string>>({
       name: 'settings',
       cwd: userDataPath,
-      defaults: {}
+      defaults: {},
     })
     stores.meta = new Store<{ version: number }>({
       name: 'meta',
       cwd: userDataPath,
-      defaults: { version: 1 }
+      defaults: { version: 1 },
     })
 
     await runMigrations()
@@ -117,9 +109,12 @@ export const getStore = <K extends keyof Stores>(name: K): Stores[K] => {
   return getInternalStore(name)
 }
 
-const getDataStore = <T>(name: DataStoreKey): Store<Record<string, T>> => {
+const getDataStore = <T>(name: RegularStoreKey): Store<Record<string, T>> => {
   return getInternalStore(name) as unknown as Store<Record<string, T>>
 }
+
+const monthlyBase = (table: 'dailyRecords' | 'taskExecutions') =>
+  table === 'dailyRecords' ? 'daily-records' : 'task-executions'
 
 const runMigrations = async (): Promise<void> => {
   const metaStore = getInternalStore('meta')
@@ -138,13 +133,12 @@ const runMigrations = async (): Promise<void> => {
 const validateDataIntegrity = async (): Promise<void> => {
   const categoryStore = getInternalStore('categories')
   const taskStore = getInternalStore('tasks')
-  const dailyRecordStore = getInternalStore('dailyRecords')
-  const taskExecutionStore = getInternalStore('taskExecutions')
-
   const categories = categoryStore.store as Record<string, Category>
   const tasks = taskStore.store as Record<string, Task>
-  const dailyRecords = dailyRecordStore.store as Record<string, DailyRecord>
-  const taskExecutions = taskExecutionStore.store as Record<string, TaskExecution>
+  const dailyRecords = getAllRecords<DailyRecord>('dailyRecords')
+  const taskExecutions = getAllRecords<TaskExecution>('taskExecutions')
+
+  const dailyRecordMap = Object.fromEntries(dailyRecords.map(r => [r.id, r]))
 
   for (const task of Object.values(tasks)) {
     if (!categories[task.categoryId]) {
@@ -154,10 +148,10 @@ const validateDataIntegrity = async (): Promise<void> => {
     }
   }
 
-  for (const execution of Object.values(taskExecutions)) {
-    if (!tasks[execution.taskId] || !dailyRecords[execution.dailyRecordId]) {
+  for (const execution of taskExecutions) {
+    if (!tasks[execution.taskId] || !dailyRecordMap[execution.dailyRecordId]) {
       console.warn(`Removing orphan task execution ${execution.id}`)
-      taskExecutionStore.delete(execution.id)
+      deleteRecord('taskExecutions', execution.id)
     }
   }
 }
@@ -226,34 +220,93 @@ export const generateId = (): string => {
 
 export const createRecord = <T extends { id: string }>(
   table: DataStoreKey,
-  record: T
+  record: T,
+  options?: { date?: string }
 ): T => {
-  const store = getDataStore<T>(table)
+  if (table === 'dailyRecords') {
+    const date = (record as any).date || options?.date
+    if (!date) throw new Error('Date required for dailyRecords')
+    const [year, month] = date.split('-')
+    const store = getMonthlyStore<DailyRecord>(monthlyBase('dailyRecords'), year, month)
+    store.set(record.id, record as any)
+    return record
+  }
+  if (table === 'taskExecutions') {
+    const date = options?.date
+    if (!date) throw new Error('Date required for taskExecutions')
+    const [year, month] = date.split('-')
+    const store = getMonthlyStore<TaskExecution>(monthlyBase('taskExecutions'), year, month)
+    store.set(record.id, record as any)
+    return record
+  }
+  const store = getDataStore<T>(table as RegularStoreKey)
   store.set(record.id, record)
   return record
 }
 
 export const getRecord = <T>(
   table: DataStoreKey,
-  id: string
+  id: string,
+  options?: { date?: string }
 ): T | null => {
-  const store = getDataStore<T>(table)
+  if (table === 'dailyRecords' || table === 'taskExecutions') {
+    const records = getAllRecords<T>(table, options)
+    return records.find((r: any) => r.id === id) || null
+  }
+  const store = getDataStore<T>(table as RegularStoreKey)
   return store.get(id) || null
 }
 
 export const getAllRecords = <T>(
-  table: DataStoreKey
+  table: DataStoreKey,
+  options?: { date?: string }
 ): T[] => {
-  const store = getDataStore<T>(table)
+  if (table === 'dailyRecords' || table === 'taskExecutions') {
+    const base = monthlyBase(table)
+    const records: T[] = []
+    if (options?.date) {
+      const [year, month] = options.date.split('-')
+      const store = getMonthlyStore<T>(base, year, month)
+      records.push(...Object.values(store.store as Record<string, T>))
+    } else {
+      for (const { year, month } of listMonthlyFiles(base)) {
+        const store = getMonthlyStore<T>(base, year, month)
+        records.push(...Object.values(store.store as Record<string, T>))
+      }
+    }
+    return records
+  }
+  const store = getDataStore<T>(table as RegularStoreKey)
   return Object.values(store.store as Record<string, T>)
 }
 
 export const updateRecord = <T extends { id: string }>(
   table: DataStoreKey,
   id: string,
-  updates: Partial<T>
+  updates: Partial<T>,
+  options?: { date?: string }
 ): T | null => {
-  const store = getDataStore<T>(table)
+  if (table === 'dailyRecords' || table === 'taskExecutions') {
+    const base = monthlyBase(table)
+    const applyUpdate = (year: string, month: string): T | null => {
+      const store = getMonthlyStore<T>(base, year, month)
+      const existing = store.get(id) as T | undefined
+      if (!existing) return null
+      const updated = { ...existing, ...updates } as T
+      store.set(id, updated)
+      return updated
+    }
+    if (options?.date) {
+      const [y, m] = options.date.split('-')
+      return applyUpdate(y, m)
+    }
+    for (const { year, month } of listMonthlyFiles(base)) {
+      const res = applyUpdate(year, month)
+      if (res) return res
+    }
+    return null
+  }
+  const store = getDataStore<T>(table as RegularStoreKey)
   const existing = store.get(id)
   if (!existing) return null
   const updated = { ...existing, ...updates }
@@ -263,9 +316,27 @@ export const updateRecord = <T extends { id: string }>(
 
 export const deleteRecord = (
   table: DataStoreKey,
-  id: string
+  id: string,
+  options?: { date?: string }
 ): boolean => {
-  const store = getDataStore<any>(table)
+  if (table === 'dailyRecords' || table === 'taskExecutions') {
+    const base = monthlyBase(table)
+    const remove = (year: string, month: string): boolean => {
+      const store = getMonthlyStore<any>(base, year, month)
+      if (!store.has(id)) return false
+      store.delete(id)
+      return true
+    }
+    if (options?.date) {
+      const [y, m] = options.date.split('-')
+      return remove(y, m)
+    }
+    for (const { year, month } of listMonthlyFiles(base)) {
+      if (remove(year, month)) return true
+    }
+    return false
+  }
+  const store = getDataStore<any>(table as RegularStoreKey)
   if (!store.has(id)) return false
   store.delete(id)
   return true
@@ -274,10 +345,17 @@ export const deleteRecord = (
 export const createBackup = (): string => {
   const categories = getInternalStore('categories').store
   const tasks = getInternalStore('tasks').store
-  const dailyRecords = getInternalStore('dailyRecords').store
-  const taskExecutions = getInternalStore('taskExecutions').store
+  const dailyRecordsArr = getAllRecords<DailyRecord>('dailyRecords')
+  const taskExecutionsArr = getAllRecords<TaskExecution>('taskExecutions')
   const settings = getInternalStore('settings').store
   const version = getInternalStore('meta').get('version', 1)
+
+  const dailyRecords = Object.fromEntries(
+    dailyRecordsArr.map(r => [r.id, r])
+  )
+  const taskExecutions = Object.fromEntries(
+    taskExecutionsArr.map(e => [e.id, e])
+  )
 
   const allData = {
     categories,
@@ -302,8 +380,6 @@ export const restoreFromBackup = (backupData: string): void => {
 
     const categoryStore = getInternalStore('categories')
     const taskStore = getInternalStore('tasks')
-    const dailyRecordStore = getInternalStore('dailyRecords')
-    const taskExecutionStore = getInternalStore('taskExecutions')
     const settingsStore = getInternalStore('settings')
     const metaStore = getInternalStore('meta')
 
@@ -316,15 +392,23 @@ export const restoreFromBackup = (backupData: string): void => {
     for (const [id, value] of Object.entries<Record<string, Task>>(data.tasks)) {
       taskStore.set(id, value)
     }
+    fs.rmSync(path.join(userDataPath, 'daily-records'), { recursive: true, force: true })
+    fs.rmSync(path.join(userDataPath, 'task-executions'), { recursive: true, force: true })
 
-    dailyRecordStore.clear()
-    for (const [id, value] of Object.entries<Record<string, DailyRecord>>(data.dailyRecords)) {
-      dailyRecordStore.set(id, value)
+    for (const value of Object.values<Record<string, DailyRecord>>(data.dailyRecords)) {
+      createRecord('dailyRecords', value)
     }
 
-    taskExecutionStore.clear()
-    for (const [id, value] of Object.entries<Record<string, TaskExecution>>(data.taskExecutions)) {
-      taskExecutionStore.set(id, value)
+    const recordDateMap: Record<string, string> = {}
+    for (const value of Object.values<Record<string, DailyRecord>>(data.dailyRecords)) {
+      recordDateMap[value.id] = value.date
+    }
+
+    for (const value of Object.values<Record<string, TaskExecution>>(data.taskExecutions)) {
+      const date = recordDateMap[value.dailyRecordId]
+      if (date) {
+        createRecord('taskExecutions', value, { date })
+      }
     }
 
     settingsStore.clear()
@@ -344,14 +428,14 @@ export const restoreFromBackup = (backupData: string): void => {
 export const getDatabaseStats = () => {
   const categories = getInternalStore('categories').store as Record<string, Category>
   const tasks = getInternalStore('tasks').store as Record<string, Task>
-  const dailyRecords = getInternalStore('dailyRecords').store as Record<string, DailyRecord>
-  const taskExecutions = getInternalStore('taskExecutions').store as Record<string, TaskExecution>
+  const dailyRecordsCount = getAllRecords<DailyRecord>('dailyRecords').length
+  const taskExecutionsCount = getAllRecords<TaskExecution>('taskExecutions').length
 
   return {
     categoriesCount: Object.keys(categories).length,
     tasksCount: Object.keys(tasks).length,
-    dailyRecordsCount: Object.keys(dailyRecords).length,
-    taskExecutionsCount: Object.keys(taskExecutions).length,
+    dailyRecordsCount,
+    taskExecutionsCount,
     databaseVersion: getInternalStore('meta').get('version', 0)
   }
 }

--- a/main/ipc-handlers.ts
+++ b/main/ipc-handlers.ts
@@ -483,7 +483,7 @@ export const setupIpcHandlers = (): void => {
   // Daily records operations
   ipcMain.handle('daily-records:get', async (event, date) => {
     try {
-      const dailyRecords = getAllRecords<DailyRecord>('dailyRecords')
+      const dailyRecords = getAllRecords<DailyRecord>('dailyRecords', { date })
       const record = dailyRecords.find(record => record.date === date)
       
       if (!record) {
@@ -491,7 +491,7 @@ export const setupIpcHandlers = (): void => {
       }
       
       // 関連するタスク実行記録も取得
-      const taskExecutions = getAllRecords<TaskExecution>('taskExecutions')
+      const taskExecutions = getAllRecords<TaskExecution>('taskExecutions', { date })
       const recordExecutions = taskExecutions.filter(execution => execution.dailyRecordId === record.id)
       
       return { 
@@ -512,7 +512,7 @@ export const setupIpcHandlers = (): void => {
       const { date, taskExecutions } = recordData
       
       // 既存の記録があるかチェック
-      const dailyRecords = getAllRecords<DailyRecord>('dailyRecords')
+      const dailyRecords = getAllRecords<DailyRecord>('dailyRecords', { date })
       let existingRecord = dailyRecords.find(record => record.date === date)
       
       // 合計金額を計算
@@ -522,20 +522,20 @@ export const setupIpcHandlers = (): void => {
       
       let dailyRecord: DailyRecord
       
-      if (existingRecord) {
-        // 既存記録を更新
-        dailyRecord = updateRecord<DailyRecord>('dailyRecords', existingRecord.id, {
-          totalAmount,
-          updatedAt: new Date().toISOString()
-        })!
-        
-        // 既存のタスク実行記録を削除
-        const allExecutions = getAllRecords<TaskExecution>('taskExecutions')
-        const executionsToDelete = allExecutions.filter(execution => execution.dailyRecordId === existingRecord.id)
-        for (const execution of executionsToDelete) {
-          deleteRecord('taskExecutions', execution.id)
-        }
-      } else {
+        if (existingRecord) {
+          // 既存記録を更新
+          dailyRecord = updateRecord<DailyRecord>('dailyRecords', existingRecord.id, {
+            totalAmount,
+            updatedAt: new Date().toISOString()
+          }, { date })!
+
+          // 既存のタスク実行記録を削除
+          const allExecutions = getAllRecords<TaskExecution>('taskExecutions', { date })
+          const executionsToDelete = allExecutions.filter(execution => execution.dailyRecordId === existingRecord.id)
+          for (const execution of executionsToDelete) {
+            deleteRecord('taskExecutions', execution.id, { date })
+          }
+        } else {
         // 新しい記録を作成
         dailyRecord = createRecord('dailyRecords', {
           id: generateId(),
@@ -560,7 +560,7 @@ export const setupIpcHandlers = (): void => {
           adjustedAt: executionData.adjustedAt
         }
         
-        const savedExecution = createRecord('taskExecutions', execution)
+          const savedExecution = createRecord('taskExecutions', execution, { date })
         savedExecutions.push(savedExecution)
       }
       
@@ -659,7 +659,7 @@ export const setupIpcHandlers = (): void => {
  // Calculation operations
   ipcMain.handle('calculation:calculate', async (event, date) => {
     try {
-      const dailyRecords = getAllRecords<DailyRecord>('dailyRecords')
+      const dailyRecords = getAllRecords<DailyRecord>('dailyRecords', { date })
       const record = dailyRecords.find(record => record.date === date)
       
       if (!record) {
@@ -667,7 +667,7 @@ export const setupIpcHandlers = (): void => {
       }
       
       // 関連するタスク実行記録を取得
-      const taskExecutions = getAllRecords<TaskExecution>('taskExecutions')
+      const taskExecutions = getAllRecords<TaskExecution>('taskExecutions', { date })
       const recordExecutions = taskExecutions.filter(execution => execution.dailyRecordId === record.id)
       
       // タスクとカテゴリ情報を取得

--- a/main/monthly-store.ts
+++ b/main/monthly-store.ts
@@ -1,0 +1,34 @@
+import Store from 'electron-store'
+import { app } from 'electron'
+import path from 'path'
+import fs from 'fs'
+
+export const getMonthlyStore = <T>(baseName: string, year: string, month: string): Store<Record<string, T>> => {
+  const userDataPath = app.getPath('userData')
+  const dir = path.join(userDataPath, baseName, year)
+  return new Store<Record<string, T>>({
+    name: month,
+    cwd: dir,
+    defaults: {}
+  })
+}
+
+export const loadMonthlyData = <T>(baseName: string, year: string, month: string): Record<string, T> => {
+  return getMonthlyStore<T>(baseName, year, month).store as Record<string, T>
+}
+
+export const listMonthlyFiles = (baseName: string): { year: string; month: string }[] => {
+  const userDataPath = app.getPath('userData')
+  const baseDir = path.join(userDataPath, baseName)
+  if (!fs.existsSync(baseDir)) return []
+  const years = fs.readdirSync(baseDir).filter(y => fs.statSync(path.join(baseDir, y)).isDirectory())
+  const result: { year: string; month: string }[] = []
+  for (const year of years) {
+    const dir = path.join(baseDir, year)
+    const files = fs.readdirSync(dir).filter(f => f.endsWith('.json'))
+    for (const file of files) {
+      result.push({ year, month: file.replace('.json', '') })
+    }
+  }
+  return result
+}


### PR DESCRIPTION
## Summary
- store `dailyRecords` and `taskExecutions` in YYYY/MM.json files
- add monthly store utilities and date-scoped database helpers
- load only targeted month when fetching records

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: see errors above)*
- `npm run type-check` *(fails: see errors above)*

------
https://chatgpt.com/codex/tasks/task_e_68a91e3f12bc8320b3ed0a6abf7f8e31