### PR TITLE
feat: load existing daily input

### DIFF
--- a/main/ipc-handlers.ts
+++ b/main/ipc-handlers.ts
@@ -15,7 +15,7 @@ import {
   type DailyRecord,
   type TaskExecution
 } from './database'
-import { taskExecutionHelpers } from './database-helpers'
+import { taskExecutionHelpers, dailyRecordHelpers } from './database-helpers'
 
 // 印刷用HTML生成関数
 const generatePrintHTML = (printData: any): string => {
@@ -573,6 +573,20 @@ export const setupIpcHandlers = (): void => {
       }
     } catch (error) {
       console.error('Failed to save daily record:', error)
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }
+    }
+  })
+
+  ipcMain.handle('daily-records:delete', async (event, date) => {
+    try {
+      const record = dailyRecordHelpers.getByDate(date)
+      if (record) {
+        const deleted = dailyRecordHelpers.delete(record.id)
+        return { success: deleted }
+      }
+      return { success: true }
+    } catch (error) {
+      console.error('Failed to delete daily record:', error)
       return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }
     }
   })

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -23,6 +23,7 @@ const IPC_EVENTS = {
   // Daily Records
   DAILY_RECORDS_GET: 'daily-records:get',
   DAILY_RECORDS_SAVE: 'daily-records:save',
+  DAILY_RECORDS_DELETE: 'daily-records:delete',
 
   // Task Executions
   TASK_EXECUTIONS_ADJUST_AMOUNT: 'task-executions:adjust-amount',
@@ -83,6 +84,7 @@ const electronAPI = {
   // Daily records
   getDailyRecord: createSecureInvoker(IPC_EVENTS.DAILY_RECORDS_GET),
   saveDailyRecord: createSecureInvoker(IPC_EVENTS.DAILY_RECORDS_SAVE),
+  deleteDailyRecord: createSecureInvoker(IPC_EVENTS.DAILY_RECORDS_DELETE),
 
   // Task executions
   adjustTaskExecutionAmount: createSecureInvoker(IPC_EVENTS.TASK_EXECUTIONS_ADJUST_AMOUNT),

--- a/src/pages/DailyInputPage.tsx
+++ b/src/pages/DailyInputPage.tsx
@@ -393,7 +393,7 @@ const DailyInputPage: React.FC = () => {
           {/* 選択済みタスク */}
           {selectedTasksByCategory.length > 0 && (
             <div className="bg-white rounded-lg shadow-md p-6">
-              <h3 className="text-lg font-bold text-gray-800 mb-4">えらんだタスク</h3>
+              <h3 className="text-lg font-bold text-gray-800 mb-4">選んだタスク</h3>
               {selectedTasksByCategory.map(({ category, tasks }) => (
                 <div key={category.id} className="mb-4 last:mb-0">
                   <h4 className="font-medium text-gray-700 flex items-center">

--- a/src/pages/DailyInputPage.tsx
+++ b/src/pages/DailyInputPage.tsx
@@ -161,6 +161,11 @@ const DailyInputPage: React.FC = () => {
     }
   }
 
+  const handleClear = () => {
+    setSelectedTasks({})
+    setIsEditing(false)
+  }
+
   if (isLoading) {
     return (
       <div className="max-w-4xl mx-auto">
@@ -260,12 +265,6 @@ const DailyInputPage: React.FC = () => {
           })}
         </div>
       </div>
-
-      {isEditing && (
-        <div className="bg-blue-50 border border-blue-200 text-blue-700 p-4 rounded mb-8">
-          前回の入力内容を読み込みました。続きから編集できます。
-        </div>
-      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         {/* メインコンテンツ */}
@@ -388,13 +387,22 @@ const DailyInputPage: React.FC = () => {
             </div>
 
             {Object.keys(selectedTasks).length > 0 && (
-              <button
-                onClick={handleSave}
-                className="w-full bg-green-600 hover:bg-green-700 text-white px-6 py-3 rounded-md font-medium inline-flex items-center justify-center"
-              >
-                <span className="text-2xl mr-2">💾</span>
-                記録を保存
-              </button>
+              <>
+                <button
+                  onClick={handleSave}
+                  className="w-full bg-green-600 hover:bg-green-700 text-white px-6 py-3 rounded-md font-medium inline-flex items-center justify-center"
+                >
+                  <span className="text-2xl mr-2">💾</span>
+                  記録を保存
+                </button>
+                <button
+                  onClick={handleClear}
+                  className="w-full mt-3 bg-gray-200 hover:bg-gray-300 text-gray-800 px-6 py-2 rounded-md font-medium inline-flex items-center justify-center"
+                >
+                  <span className="text-xl mr-2">🗑️</span>
+                  入力内容をクリア
+                </button>
+              </>
             )}
           </div>
 

--- a/src/pages/DailyInputPage.tsx
+++ b/src/pages/DailyInputPage.tsx
@@ -16,6 +16,7 @@ const DailyInputPage: React.FC = () => {
   const [selectedTasks, setSelectedTasks] = useState<Record<string, number>>({})
   const [currentDate] = useState(() => new Date().toISOString().split('T')[0])
   const [activeCategoryId, setActiveCategoryId] = useState<string>('')
+  const [isEditing, setIsEditing] = useState(false)
 
   // データの初期読み込み
   useEffect(() => {
@@ -42,6 +43,18 @@ const DailyInputPage: React.FC = () => {
           console.log('[DailyInputPage] Tasks loaded:', tasksResponse.data.length)
         } else {
           throw new Error('タスクの読み込みに失敗しました')
+        }
+
+        // 既存の記録を読み込み
+        const existingRecord = await window.electronAPI.getDailyRecord(currentDate)
+        if (existingRecord.success && existingRecord.data) {
+          const initialSelected: Record<string, number> = {}
+          for (const exec of existingRecord.data.taskExecutions) {
+            initialSelected[exec.taskId] = exec.count
+          }
+          setSelectedTasks(initialSelected)
+          setIsEditing(true)
+          console.log('[DailyInputPage] Existing record loaded')
         }
       } catch (error) {
         console.error('[DailyInputPage] Error loading data:', error)
@@ -102,11 +115,13 @@ const DailyInputPage: React.FC = () => {
     try {
       console.log('[DailyInputPage] Saving record...')
 
-      const existing = await window.electronAPI.getDailyRecord(currentDate)
-      if (existing.success && existing.data) {
-        const overwrite = window.confirm(getDuplicateDateMessage(currentDate))
-        if (!overwrite) {
-          return
+      if (!isEditing) {
+        const existing = await window.electronAPI.getDailyRecord(currentDate)
+        if (existing.success && existing.data) {
+          const overwrite = window.confirm(getDuplicateDateMessage(currentDate))
+          if (!overwrite) {
+            return
+          }
         }
       }
 
@@ -133,7 +148,10 @@ const DailyInputPage: React.FC = () => {
             Object.keys(selectedTasks).length
           )
         )
-        setSelectedTasks({})
+        setIsEditing(true)
+        if (!isEditing) {
+          setSelectedTasks({})
+        }
       } else {
         throw new Error(result.error || '保存に失敗しました')
       }
@@ -242,6 +260,12 @@ const DailyInputPage: React.FC = () => {
           })}
         </div>
       </div>
+
+      {isEditing && (
+        <div className="bg-blue-50 border border-blue-200 text-blue-700 p-4 rounded mb-8">
+          前回の入力内容を読み込みました。続きから編集できます。
+        </div>
+      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         {/* メインコンテンツ */}

--- a/src/pages/DailyInputPage.tsx
+++ b/src/pages/DailyInputPage.tsx
@@ -363,29 +363,6 @@ const DailyInputPage: React.FC = () => {
 
         {/* サイドバー */}
         <div className="space-y-6">
-          {/* 選択済みタスク */}
-          {selectedTasksByCategory.length > 0 && (
-            <div className="bg-white rounded-lg shadow-md p-6">
-              <h3 className="text-lg font-bold text-gray-800 mb-4">えらんだタスク</h3>
-              {selectedTasksByCategory.map(({ category, tasks }) => (
-                <div key={category.id} className="mb-4 last:mb-0">
-                  <h4 className="font-medium text-gray-700 flex items-center">
-                    <span className="text-xl mr-2">{category.icon}</span>
-                    {category.name}
-                  </h4>
-                  <ul className="mt-2 space-y-1">
-                    {tasks.map(task => (
-                      <li key={task.id} className="flex justify-between text-sm">
-                        <span>{task.name}</span>
-                        <span>{task.count}回</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
-            </div>
-          )}
-
           {/* 合計表示 */}
           <div className="bg-white rounded-lg shadow-md p-6 text-center">
             <h3 className="text-lg font-bold text-gray-800 mb-4">今日の合計</h3>
@@ -412,6 +389,29 @@ const DailyInputPage: React.FC = () => {
               </>
             )}
           </div>
+
+          {/* 選択済みタスク */}
+          {selectedTasksByCategory.length > 0 && (
+            <div className="bg-white rounded-lg shadow-md p-6">
+              <h3 className="text-lg font-bold text-gray-800 mb-4">えらんだタスク</h3>
+              {selectedTasksByCategory.map(({ category, tasks }) => (
+                <div key={category.id} className="mb-4 last:mb-0">
+                  <h4 className="font-medium text-gray-700 flex items-center">
+                    <span className="text-xl mr-2">{category.icon}</span>
+                    {category.name}
+                  </h4>
+                  <ul className="mt-2 space-y-1">
+                    {tasks.map(task => (
+                      <li key={task.id} className="flex justify-between text-sm">
+                        <span>{task.name}</span>
+                        <span>{task.count}回</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          )}
 
           {/* ナビゲーション */}
           <div className="bg-white rounded-lg shadow-md p-6">

--- a/src/pages/DailyInputPage.tsx
+++ b/src/pages/DailyInputPage.tsx
@@ -162,8 +162,10 @@ const DailyInputPage: React.FC = () => {
   }
 
   const handleClear = () => {
-    setSelectedTasks({})
-    setIsEditing(false)
+    if (window.confirm('入力内容をクリアしますか？')) {
+      setSelectedTasks({})
+      setIsEditing(false)
+    }
   }
 
   if (isLoading) {

--- a/src/pages/DailyInputPage.tsx
+++ b/src/pages/DailyInputPage.tsx
@@ -149,9 +149,6 @@ const DailyInputPage: React.FC = () => {
           )
         )
         setIsEditing(true)
-        if (!isEditing) {
-          setSelectedTasks({})
-        }
       } else {
         throw new Error(result.error || '保存に失敗しました')
       }

--- a/src/pages/DailyInputPage.tsx
+++ b/src/pages/DailyInputPage.tsx
@@ -161,10 +161,18 @@ const DailyInputPage: React.FC = () => {
     }
   }
 
-  const handleClear = () => {
+  const handleClear = async () => {
     if (window.confirm('入力内容をクリアしますか？')) {
-      setSelectedTasks({})
-      setIsEditing(false)
+      try {
+        if (isEditing) {
+          await window.electronAPI.deleteDailyRecord(currentDate)
+        }
+        setSelectedTasks({})
+        setIsEditing(false)
+      } catch (error) {
+        console.error('[DailyInputPage] Error deleting record:', error)
+        alert('記録の削除に失敗しました')
+      }
     }
   }
 

--- a/src/services/electronAPI.ts
+++ b/src/services/electronAPI.ts
@@ -120,6 +120,13 @@ class ElectronAPIService {
     )
   }
 
+  async deleteDailyRecord(date: string): Promise<ApiResponse> {
+    return this.handleAPICall(
+      () => window.electronAPI.deleteDailyRecord(date),
+      '日次記録削除'
+    )
+  }
+
   // Calculation
   async calculateAllowance(date: string): Promise<ApiResponse> {
     return this.handleAPICall(

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -44,6 +44,7 @@ export interface ElectronAPI {
     date: string
     taskExecutions: Omit<TaskExecution, 'id' | 'dailyRecordId'>[]
   }) => Promise<ApiResponse<DailyRecord & { taskExecutions: TaskExecution[] }>>
+  deleteDailyRecord: (date: string) => Promise<ApiResponse<void>>
 
   // Task executions
   adjustTaskExecutionAmount: (id: string, adjustedAmount: number, reason: string) => Promise<ApiResponse<TaskExecution | null>>
@@ -99,6 +100,7 @@ export interface IPCEventMap {
   // Daily records
   'daily-records:get': (date: string) => Promise<ApiResponse<DailyRecord | null>>
   'daily-records:save': (record: any) => Promise<ApiResponse<DailyRecord>>
+  'daily-records:delete': (date: string) => Promise<ApiResponse<void>>
 
   // Task executions
   'task-executions:adjust-amount': (id: string, adjustedAmount: number, reason: string) => Promise<ApiResponse<TaskExecution | null>>

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -27,6 +27,7 @@ exports.IPC_EVENTS = {
     // Daily Records
     DAILY_RECORDS_GET: 'daily-records:get',
     DAILY_RECORDS_SAVE: 'daily-records:save',
+    DAILY_RECORDS_DELETE: 'daily-records:delete',
     // Calculation
     CALCULATION_CALCULATE: 'calculation:calculate',
     // History


### PR DESCRIPTION
## Summary
- load existing daily record on the daily input page so kids can resume edits
- skip duplicate confirmation for loaded records and keep selections after saving
- show a banner when previous input is restored

## Testing
- `npm run lint` (fails: ESLint couldn't find config "@typescript-eslint/recommended")
- `npm run type-check` (fails: several missing type exports in utils)


------
https://chatgpt.com/codex/tasks/task_e_68aa6a8ea794832082406795cebaff77