### PR TITLE
feat: unify bottom navigation across pages

### DIFF
--- a/src/components/common/BottomNavigation.tsx
+++ b/src/components/common/BottomNavigation.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { navigationItems } from '../../constants/navigation'
+
+interface Props {
+  current: string
+}
+
+const BottomNavigation: React.FC<Props> = ({ current }) => {
+  const items = navigationItems.filter(item => item.id !== current)
+
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200">
+      <div className="max-w-4xl mx-auto flex flex-wrap justify-around gap-2 p-4">
+        {items.map(item => (
+          <Link
+            key={item.id}
+            to={item.path}
+            className={`${item.color} text-white px-4 py-2 rounded-md text-sm font-medium inline-flex items-center`}
+          >
+            <span className="mr-1 text-xl">{item.icon}</span>
+            <span>{item.title}</span>
+          </Link>
+        ))}
+      </div>
+    </nav>
+  )
+}
+
+export default BottomNavigation

--- a/src/components/common/Navigation.tsx
+++ b/src/components/common/Navigation.tsx
@@ -1,60 +1,11 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
-
-interface NavigationItem {
-  id: string
-  title: string
-  description: string
-  icon: string
-  color: string
-  path: string
-}
+import { navigationItems } from '../../constants/navigation'
 
 const Navigation: React.FC = () => {
   const navigate = useNavigate()
 
-  const navigationItems: NavigationItem[] = [
-    {
-      id: 'category-management',
-      title: 'カテゴリ管理',
-      description: 'タスクの種類を整理しよう',
-      icon: '📂',
-      color: 'bg-indigo-500 hover:bg-indigo-600',
-      path: '/category-management'
-    },
-    {
-      id: 'task-management',
-      title: 'タスク管理',
-      description: 'お手伝いや宿題を登録しよう',
-      icon: '📝',
-      color: 'bg-blue-500 hover:bg-blue-600',
-      path: '/task-management'
-    },
-    {
-      id: 'daily-input',
-      title: '今日のタスク入力',
-      description: 'やったことを記録しよう',
-      icon: '✅',
-      color: 'bg-green-500 hover:bg-green-600',
-      path: '/daily-input'
-    },
-    {
-      id: 'calculation',
-      title: 'おこづかい計算',
-      description: 'いくらもらえるか計算しよう',
-      icon: '💰',
-      color: 'bg-yellow-500 hover:bg-yellow-600',
-      path: '/calculation'
-    },
-    {
-      id: 'history',
-      title: '履歴を見る',
-      description: '過去の記録を確認しよう',
-      icon: '📊',
-      color: 'bg-purple-500 hover:bg-purple-600',
-      path: '/history'
-    }
-  ]
+  const items = navigationItems.filter(item => item.id !== 'home')
 
   const handleNavigation = (path: string) => {
     navigate(path)
@@ -62,7 +13,7 @@ const Navigation: React.FC = () => {
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-      {navigationItems.map((item, index) => (
+      {items.map((item, index) => (
         <button
           key={item.id}
           onClick={() => handleNavigation(item.path)}

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -1,0 +1,58 @@
+export interface NavigationItem {
+  id: string
+  title: string
+  description?: string
+  icon: string
+  color: string
+  path: string
+}
+
+export const navigationItems: NavigationItem[] = [
+  {
+    id: 'category-management',
+    title: 'カテゴリ管理',
+    description: 'タスクの種類を整理しよう',
+    icon: '📂',
+    color: 'bg-indigo-500 hover:bg-indigo-600',
+    path: '/category-management'
+  },
+  {
+    id: 'task-management',
+    title: 'タスク管理',
+    description: 'お手伝いや宿題を登録しよう',
+    icon: '📝',
+    color: 'bg-blue-500 hover:bg-blue-600',
+    path: '/task-management'
+  },
+  {
+    id: 'daily-input',
+    title: '今日のタスク入力',
+    description: 'やったことを記録しよう',
+    icon: '✅',
+    color: 'bg-green-500 hover:bg-green-600',
+    path: '/daily-input'
+  },
+  {
+    id: 'calculation',
+    title: 'おこづかい計算',
+    description: 'いくらもらえるか計算しよう',
+    icon: '💰',
+    color: 'bg-yellow-500 hover:bg-yellow-600',
+    path: '/calculation'
+  },
+  {
+    id: 'history',
+    title: '履歴を見る',
+    description: '過去の記録を確認しよう',
+    icon: '📊',
+    color: 'bg-purple-500 hover:bg-purple-600',
+    path: '/history'
+  },
+  {
+    id: 'home',
+    title: 'ホーム',
+    icon: '🏠',
+    color: 'bg-gray-500 hover:bg-gray-600',
+    path: '/'
+  }
+]

--- a/src/pages/CalculationPage.tsx
+++ b/src/pages/CalculationPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react'
 import { Link } from 'react-router-dom'
+import BottomNavigation from '../components/common/BottomNavigation'
 
 /**
  * おこづかい計算ページ（シンプル版）
@@ -169,7 +170,8 @@ const CalculationPage: React.FC = () => {
   }
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <>
+      <div className="max-w-4xl mx-auto pb-24">
       <div className="text-center mb-8">
         <h1 className="text-3xl font-bold text-gray-800 mb-2">
           おこづかい計算
@@ -389,30 +391,9 @@ const CalculationPage: React.FC = () => {
         </div>
       )}
 
-      {/* ナビゲーション */}
-      <div className="mt-8 text-center">
-        <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <Link to="/daily-input">
-            <button className="bg-gray-600 hover:bg-gray-700 text-white px-6 py-3 rounded-md font-medium inline-flex items-center">
-              <span className="text-2xl mr-2">📝</span>
-              タスク入力
-            </button>
-          </Link>
-          <Link to="/history">
-            <button className="bg-gray-600 hover:bg-gray-700 text-white px-6 py-3 rounded-md font-medium inline-flex items-center">
-              <span className="text-2xl mr-2">📊</span>
-              履歴を見る
-            </button>
-          </Link>
-          <Link to="/">
-            <button className="bg-gray-600 hover:bg-gray-700 text-white px-6 py-3 rounded-md font-medium inline-flex items-center">
-              <span className="text-2xl mr-2">🏠</span>
-              ホームに戻る
-            </button>
-          </Link>
-        </div>
       </div>
-    </div>
+      <BottomNavigation current="calculation" />
+    </>
   )
 }
 

--- a/src/pages/CategoryManagementPage.tsx
+++ b/src/pages/CategoryManagementPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
-import { Link } from 'react-router-dom'
 import { Category } from '../types'
 import TaskValidator from '../utils/taskValidation'
+import BottomNavigation from '../components/common/BottomNavigation'
 
 const CategoryManagementPage: React.FC = () => {
   const [categories, setCategories] = useState<Category[]>([])
@@ -104,7 +104,7 @@ const CategoryManagementPage: React.FC = () => {
 
   if (isLoading) {
     return (
-      <div className="max-w-4xl mx-auto">
+    <div className="max-w-4xl mx-auto pb-24">
         <div className="flex justify-center items-center py-12">
           <div className="text-center">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
@@ -119,7 +119,7 @@ const CategoryManagementPage: React.FC = () => {
 
   if (error) {
     return (
-      <div className="max-w-4xl mx-auto">
+        <div className="max-w-4xl mx-auto pb-24">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-gray-800 mb-2">
             カテゴリ管理
@@ -223,7 +223,7 @@ const CategoryManagementPage: React.FC = () => {
         </div>
       )}
 
-      <div className="max-w-4xl mx-auto">
+      <div className="max-w-4xl mx-auto pb-24">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-gray-800 mb-2">
             カテゴリ管理
@@ -305,30 +305,8 @@ const CategoryManagementPage: React.FC = () => {
         )}
       </div>
 
-        {/* ナビゲーション */}
-        <div className="text-center">
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link to="/task-management">
-              <button className="bg-green-600 hover:bg-green-700 text-white px-6 py-3 rounded-md font-medium inline-flex items-center">
-                <span className="text-2xl mr-2">✅</span>
-                タスク管理
-              </button>
-            </Link>
-            <Link to="/daily-input">
-              <button className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-md font-medium inline-flex items-center">
-                <span className="text-2xl mr-2">📝</span>
-                タスク入力
-              </button>
-            </Link>
-            <Link to="/">
-              <button className="bg-gray-600 hover:bg-gray-700 text-white px-6 py-3 rounded-md font-medium inline-flex items-center">
-                <span className="text-2xl mr-2">🏠</span>
-                ホームに戻る
-              </button>
-            </Link>
-          </div>
-        </div>
       </div>
+      <BottomNavigation current="category-management" />
     </>
   )
 }

--- a/src/pages/DailyInputPage.tsx
+++ b/src/pages/DailyInputPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
+import BottomNavigation from '../components/common/BottomNavigation'
 import { Task, Category } from '../types'
 import {
   validateDailyInput,
@@ -254,7 +255,8 @@ const DailyInputPage: React.FC = () => {
   }
 
   return (
-    <div className="max-w-6xl mx-auto">
+    <>
+      <div className="max-w-6xl mx-auto pb-24">
       {/* ヘッダー */}
       <div className="text-center mb-8">
         <h1 className="text-3xl font-bold text-gray-800 mb-2">
@@ -413,35 +415,11 @@ const DailyInputPage: React.FC = () => {
             </div>
           )}
 
-          {/* ナビゲーション */}
-          <div className="bg-white rounded-lg shadow-md p-6">
-            <h3 className="text-lg font-bold text-gray-800 mb-4">
-              その他の機能
-            </h3>
-            <div className="space-y-3">
-              <Link to="/calculation">
-                <button className="w-full bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md font-medium inline-flex items-center justify-center">
-                  <span className="text-xl mr-2">🧮</span>
-                  おこづかい計算
-                </button>
-              </Link>
-              <Link to="/history">
-                <button className="w-full bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md font-medium inline-flex items-center justify-center">
-                  <span className="text-xl mr-2">📊</span>
-                  履歴を見る
-                </button>
-              </Link>
-              <Link to="/">
-                <button className="w-full bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md font-medium inline-flex items-center justify-center">
-                  <span className="text-xl mr-2">🏠</span>
-                  ホームに戻る
-                </button>
-              </Link>
-            </div>
-          </div>
         </div>
       </div>
-    </div>
+      </div>
+      <BottomNavigation current="daily-input" />
+    </>
   )
 }
 

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react'
 import { electronAPI } from '../services/electronAPI'
 import { StatisticsData } from '../types'
+import BottomNavigation from '../components/common/BottomNavigation'
 
 const HistoryPage: React.FC = () => {
   const today = new Date().toISOString().split('T')[0]
@@ -113,7 +114,8 @@ const HistoryPage: React.FC = () => {
     .join(' ')
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <>
+      <div className="max-w-4xl mx-auto pb-24">
       <div className="text-center mb-8">
         <h1 className="text-3xl font-bold text-gray-800 mb-2">履歴を見る</h1>
         <p className="text-child-friendly text-gray-600">過去のおこづかい記録を確認しよう</p>
@@ -250,7 +252,9 @@ const HistoryPage: React.FC = () => {
           </section>
         </div>
       )}
-    </div>
+      </div>
+      <BottomNavigation current="history" />
+    </>
   )
 }
 

--- a/src/pages/TaskManagementPage.tsx
+++ b/src/pages/TaskManagementPage.tsx
@@ -4,6 +4,7 @@ import { Task, Category, CreateInput } from '../types'
 import TaskValidator from '../utils/taskValidation'
 import ConfirmDialog from '../components/common/ConfirmDialog'
 import Alert from '../components/common/Alert'
+import BottomNavigation from '../components/common/BottomNavigation'
 
 const TaskManagementPage: React.FC = () => {
   const [tasks, setTasks] = useState<Task[]>([])
@@ -309,7 +310,7 @@ const TaskManagementPage: React.FC = () => {
         </div>
       )}
 
-      <div className="max-w-6xl mx-auto">
+      <div className="max-w-6xl mx-auto pb-24">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-gray-800 mb-2">タスク管理</h1>
           <p className="text-gray-600">お手伝いや宿題を登録・編集できます</p>
@@ -463,29 +464,6 @@ const TaskManagementPage: React.FC = () => {
           </div>
         </div>
 
-        {/* アクションボタン */}
-        <div className="mt-8 text-center">
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link to="/daily-input">
-              <button className="bg-green-600 hover:bg-green-700 text-white px-6 py-3 rounded-md font-medium inline-flex items-center">
-                <span className="text-2xl mr-2">📝</span>
-                タスクを記録する
-              </button>
-            </Link>
-            <Link to="/calculation">
-              <button className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-md font-medium inline-flex items-center">
-                <span className="text-2xl mr-2">🧮</span>
-                おこづかいを計算する
-              </button>
-            </Link>
-            <Link to="/">
-              <button className="bg-gray-600 hover:bg-gray-700 text-white px-6 py-3 rounded-md font-medium inline-flex items-center">
-                <span className="text-2xl mr-2">🏠</span>
-                ホームに戻る
-              </button>
-            </Link>
-          </div>
-        </div>
       </div>
 
       {confirmState && (
@@ -496,6 +474,7 @@ const TaskManagementPage: React.FC = () => {
           onCancel={handleConfirmCancel}
         />
       )}
+      <BottomNavigation current="task-management" />
     </>
   )
 }


### PR DESCRIPTION
## Summary
- add reusable bottom navigation component with shared page config
- replace per-page nav sections with bottom navigation on each screen
- centralize navigation color scheme

## Testing
- `npm run lint` *(fails: ESLint couldn't find the config "@typescript-eslint/recommended")*
- `npm run type-check` *(fails: multiple TypeScript errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7a95dcdc83209c7e4be40a428a2d