### PR TITLE
feat: enable date selection for task input

### DIFF
--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -26,7 +26,7 @@ export const navigationItems: NavigationItem[] = [
   },
   {
     id: 'daily-input',
-    title: '今日のタスク入力',
+    title: 'タスク入力',
     description: 'やったことを記録しよう',
     icon: '✅',
     color: 'bg-green-500 hover:bg-green-600',

--- a/src/pages/CalculationPage.tsx
+++ b/src/pages/CalculationPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react'
+import React, { useState, useEffect, useMemo, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import BottomNavigation from '../components/common/BottomNavigation'
 
@@ -9,6 +9,7 @@ const CalculationPage: React.FC = () => {
   const [selectedDate, setSelectedDate] = useState<string>(() => {
     return new Date().toISOString().split('T')[0]
   })
+  const dateInputRef = useRef<HTMLInputElement>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [calculation, setCalculation] = useState<any>(null)
   const [error, setError] = useState<string | null>(null)
@@ -179,35 +180,52 @@ const CalculationPage: React.FC = () => {
         <p className="text-gray-600">
           今日やったタスクからおこづかいを計算しよう
         </p>
+        <div className="flex justify-center items-center mt-4">
+          <div className="text-lg font-medium text-blue-600">
+            {new Date(selectedDate).toLocaleDateString('ja-JP', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+              weekday: 'long'
+            })}
+          </div>
+          <button
+            onClick={() => dateInputRef.current?.showPicker()}
+            className="ml-2 text-blue-600 hover:text-blue-800"
+            aria-label="日付を選択"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+          </button>
+          <input
+            ref={dateInputRef}
+            type="date"
+            value={selectedDate}
+            onChange={handleDateChange}
+            className="hidden"
+          />
+        </div>
       </div>
 
-      {/* 日付選択 */}
       <div className="bg-white rounded-lg shadow-md p-6 mb-6">
         <h2 className="text-xl font-bold text-gray-800 mb-4 flex items-center">
-          📅 計算する日付を選んでください
+          🧮 おこづかいを計算する
         </h2>
-        
-        <div className="flex flex-col sm:flex-row gap-4 items-center">
-          <div className="flex-1">
-            <input
-              id="calculation-date"
-              type="date"
-              value={selectedDate}
-              onChange={handleDateChange}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-lg"
-              disabled={isLoading}
-            />
-          </div>
 
-          <div className="flex gap-2">
-            <button
-              onClick={handleCalculate}
-              disabled={!selectedDate || isLoading}
-              className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white px-6 py-2 rounded-md font-medium"
-            >
-              {isLoading ? '計算中...' : '計算する'}
-            </button>
-          </div>
+        <div className="flex justify-center">
+          <button
+            onClick={handleCalculate}
+            disabled={!selectedDate || isLoading}
+            className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white px-6 py-2 rounded-md font-medium"
+          >
+            {isLoading ? '計算中...' : '計算する'}
+          </button>
         </div>
       </div>
 

--- a/src/pages/CalculationPage.tsx
+++ b/src/pages/CalculationPage.tsx
@@ -210,25 +210,16 @@ const CalculationPage: React.FC = () => {
             onChange={handleDateChange}
             className="hidden"
           />
-        </div>
-      </div>
-
-      <div className="bg-white rounded-lg shadow-md p-6 mb-6">
-        <h2 className="text-xl font-bold text-gray-800 mb-4 flex items-center">
-          🧮 おこづかいを計算する
-        </h2>
-
-        <div className="flex justify-center">
           <button
             onClick={handleCalculate}
             disabled={!selectedDate || isLoading}
-            className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white px-6 py-2 rounded-md font-medium"
+            className="ml-4 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white px-6 py-2 rounded-md font-medium"
           >
             {isLoading ? '計算中...' : '計算する'}
           </button>
         </div>
       </div>
-
+      
       {/* ローディング表示 */}
       {isLoading && (
         <div className="bg-white rounded-lg shadow-md p-8 text-center">

--- a/src/pages/DailyInputPage.tsx
+++ b/src/pages/DailyInputPage.tsx
@@ -15,14 +15,15 @@ const DailyInputPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selectedTasks, setSelectedTasks] = useState<Record<string, number>>({})
-  const [currentDate] = useState(() => new Date().toISOString().split('T')[0])
+  const [selectedDate, setSelectedDate] = useState(() => new Date().toISOString().split('T')[0])
   const [activeCategoryId, setActiveCategoryId] = useState<string>('')
   const [isEditing, setIsEditing] = useState(false)
 
-  // データの初期読み込み
+  // カテゴリとタスクの初期読み込み
   useEffect(() => {
     const loadData = async () => {
       try {
+        setIsLoading(true)
         console.log('[DailyInputPage] Loading data...')
         const [categoriesResponse, tasksResponse] = await Promise.all([
           window.electronAPI.getAllCategories(),
@@ -45,18 +46,6 @@ const DailyInputPage: React.FC = () => {
         } else {
           throw new Error('タスクの読み込みに失敗しました')
         }
-
-        // 既存の記録を読み込み
-        const existingRecord = await window.electronAPI.getDailyRecord(currentDate)
-        if (existingRecord.success && existingRecord.data) {
-          const initialSelected: Record<string, number> = {}
-          for (const exec of existingRecord.data.taskExecutions) {
-            initialSelected[exec.taskId] = exec.count
-          }
-          setSelectedTasks(initialSelected)
-          setIsEditing(true)
-          console.log('[DailyInputPage] Existing record loaded')
-        }
       } catch (error) {
         console.error('[DailyInputPage] Error loading data:', error)
         setError('データの読み込みに失敗しました')
@@ -67,6 +56,36 @@ const DailyInputPage: React.FC = () => {
 
     loadData()
   }, [])
+
+  // 選択した日の記録を読み込み
+  useEffect(() => {
+    const loadRecord = async () => {
+      try {
+        setIsLoading(true)
+        setError(null)
+        const existingRecord = await window.electronAPI.getDailyRecord(selectedDate)
+        if (existingRecord.success && existingRecord.data) {
+          const initialSelected: Record<string, number> = {}
+          for (const exec of existingRecord.data.taskExecutions) {
+            initialSelected[exec.taskId] = exec.count
+          }
+          setSelectedTasks(initialSelected)
+          setIsEditing(true)
+          console.log('[DailyInputPage] Existing record loaded')
+        } else {
+          setSelectedTasks({})
+          setIsEditing(false)
+        }
+      } catch (error) {
+        console.error('[DailyInputPage] Error loading record:', error)
+        setError('データの読み込みに失敗しました')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    loadRecord()
+  }, [selectedDate])
 
   // タスクの回数を設定
   const setTaskCount = (taskId: string, count: number) => {
@@ -103,7 +122,7 @@ const DailyInputPage: React.FC = () => {
   // 保存処理
   const handleSave = async () => {
     const validation = validateDailyInput(
-      { date: currentDate, selectedTasks },
+      { date: selectedDate, selectedTasks },
       tasks
     )
 
@@ -117,9 +136,9 @@ const DailyInputPage: React.FC = () => {
       console.log('[DailyInputPage] Saving record...')
 
       if (!isEditing) {
-        const existing = await window.electronAPI.getDailyRecord(currentDate)
+        const existing = await window.electronAPI.getDailyRecord(selectedDate)
         if (existing.success && existing.data) {
-          const overwrite = window.confirm(getDuplicateDateMessage(currentDate))
+          const overwrite = window.confirm(getDuplicateDateMessage(selectedDate))
           if (!overwrite) {
             return
           }
@@ -136,19 +155,19 @@ const DailyInputPage: React.FC = () => {
       })
 
       const result = await window.electronAPI.saveDailyRecord({
-        date: currentDate,
+        date: selectedDate,
         taskExecutions
       })
 
       if (result.success) {
         console.log('[DailyInputPage] Record saved successfully')
-        alert(
-          getSaveSuccessMessage(
-            currentDate,
-            totalAmount,
-            Object.keys(selectedTasks).length
+          alert(
+            getSaveSuccessMessage(
+              selectedDate,
+              totalAmount,
+              Object.keys(selectedTasks).length
+            )
           )
-        )
         setIsEditing(true)
       } else {
         throw new Error(result.error || '保存に失敗しました')
@@ -163,7 +182,7 @@ const DailyInputPage: React.FC = () => {
     if (window.confirm('入力内容をクリアしますか？')) {
       try {
         if (isEditing) {
-          await window.electronAPI.deleteDailyRecord(currentDate)
+          await window.electronAPI.deleteDailyRecord(selectedDate)
         }
         setSelectedTasks({})
         setIsEditing(false)
@@ -194,7 +213,7 @@ const DailyInputPage: React.FC = () => {
       <div className="max-w-4xl mx-auto">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-gray-800 mb-2">
-            今日のタスク入力
+            タスク入力
           </h1>
         </div>
         
@@ -225,7 +244,7 @@ const DailyInputPage: React.FC = () => {
       <div className="max-w-4xl mx-auto">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-gray-800 mb-2">
-            今日のタスク入力
+            タスク入力
           </h1>
         </div>
         
@@ -260,13 +279,21 @@ const DailyInputPage: React.FC = () => {
       {/* ヘッダー */}
       <div className="text-center mb-8">
         <h1 className="text-3xl font-bold text-gray-800 mb-2">
-          今日のタスク入力
+          タスク入力
         </h1>
         <p className="text-gray-600 mb-4">
-          今日やったお手伝いや宿題を記録しよう
+          やったお手伝いや宿題を記録しよう
         </p>
+        <div className="flex justify-center mb-2">
+          <input
+            type="date"
+            value={selectedDate}
+            onChange={e => setSelectedDate(e.target.value)}
+            className="border rounded px-3 py-1"
+          />
+        </div>
         <div className="text-lg font-medium text-blue-600">
-          {new Date(currentDate).toLocaleDateString('ja-JP', {
+          {new Date(selectedDate).toLocaleDateString('ja-JP', {
             year: 'numeric',
             month: 'long',
             day: 'numeric',
@@ -280,7 +307,7 @@ const DailyInputPage: React.FC = () => {
         <div className="lg:col-span-2">
           <div className="bg-white rounded-lg shadow-md p-6">
             <h2 className="text-xl font-bold text-gray-800 mb-4">
-              📝 今日やったタスクを選んでください
+              📝 タスクを選んでください
             </h2>
             
             <div className="mb-6 flex flex-wrap gap-2">
@@ -367,7 +394,7 @@ const DailyInputPage: React.FC = () => {
         <div className="space-y-6">
           {/* 合計表示 */}
           <div className="bg-white rounded-lg shadow-md p-6 text-center">
-            <h3 className="text-lg font-bold text-gray-800 mb-4">今日の合計</h3>
+            <h3 className="text-lg font-bold text-gray-800 mb-4">この日の合計</h3>
             <div className="text-3xl font-bold text-green-600 mb-4">
               ¥{totalAmount.toLocaleString()}
             </div>

--- a/src/pages/DailyInputPage.tsx
+++ b/src/pages/DailyInputPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import BottomNavigation from '../components/common/BottomNavigation'
 import { Task, Category } from '../types'
@@ -18,6 +18,7 @@ const DailyInputPage: React.FC = () => {
   const [selectedDate, setSelectedDate] = useState(() => new Date().toISOString().split('T')[0])
   const [activeCategoryId, setActiveCategoryId] = useState<string>('')
   const [isEditing, setIsEditing] = useState(false)
+  const dateInputRef = useRef<HTMLInputElement>(null)
 
   // カテゴリとタスクの初期読み込み
   useEffect(() => {
@@ -284,21 +285,36 @@ const DailyInputPage: React.FC = () => {
         <p className="text-gray-600 mb-4">
           やったお手伝いや宿題を記録しよう
         </p>
-        <div className="flex justify-center mb-2">
+        <div className="flex justify-center items-center mb-2">
+          <div className="text-lg font-medium text-blue-600">
+            {new Date(selectedDate).toLocaleDateString('ja-JP', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+              weekday: 'long'
+            })}
+          </div>
+          <button
+            onClick={() => dateInputRef.current?.showPicker()}
+            className="ml-2 text-blue-600 hover:text-blue-800"
+            aria-label="日付を選択"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+          </button>
           <input
+            ref={dateInputRef}
             type="date"
             value={selectedDate}
             onChange={e => setSelectedDate(e.target.value)}
-            className="border rounded px-3 py-1"
+            className="hidden"
           />
-        </div>
-        <div className="text-lg font-medium text-blue-600">
-          {new Date(selectedDate).toLocaleDateString('ja-JP', {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-            weekday: 'long'
-          })}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- allow selecting a date on the task input screen and load tasks for that day
- show selected date in the header and allow saving records by chosen date
- rename navigation label to generic "タスク入力"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find config "@typescript-eslint/recommended")*
- `npm run type-check` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7d249b0c8320ae287b647ddb4604