### PR TITLE
Show all bottom navigation buttons

### DIFF
--- a/src/components/common/BottomNavigation.tsx
+++ b/src/components/common/BottomNavigation.tsx
@@ -7,16 +7,17 @@ interface Props {
 }
 
 const BottomNavigation: React.FC<Props> = ({ current }) => {
-  const items = navigationItems.filter(item => item.id !== current)
-
   return (
     <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200">
       <div className="max-w-4xl mx-auto flex flex-wrap justify-around gap-2 p-4">
-        {items.map(item => (
+        {navigationItems.map(item => (
           <Link
             key={item.id}
             to={item.path}
-            className={`${item.color} text-white px-4 py-2 rounded-md text-sm font-medium inline-flex items-center`}
+            className={`${item.color} text-white px-4 py-2 rounded-md text-sm font-medium inline-flex items-center ${
+              item.id === current ? 'opacity-50 cursor-default pointer-events-none' : ''
+            }`}
+            aria-current={item.id === current ? 'page' : undefined}
           >
             <span className="mr-1 text-xl">{item.icon}</span>
             <span>{item.title}</span>


### PR DESCRIPTION
## Summary
- Display every navigation button, keeping layout stable
- Disable and mark current page in the bottom navigation

## Testing
- `npm run lint` *(fails: ESLint couldn't find config "@typescript-eslint/recommended")*
- `npm run type-check` *(fails: multiple TypeScript errors such as TS6133)*

------
https://chatgpt.com/codex/tasks/task_e_68aa82fe6c048320b885a1be0d6fbdd5