### PR TITLE
Add shared PageHeader component for colored captions

### DIFF
--- a/src/components/common/PageHeader.tsx
+++ b/src/components/common/PageHeader.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { navigationItems } from '../../constants/navigation'
+
+interface PageHeaderProps {
+  title: string
+  description?: string
+  navId: string
+}
+
+const PageHeader: React.FC<PageHeaderProps> = ({ title, description, navId }) => {
+  const navItem = navigationItems.find(item => item.id === navId)
+  const colorClasses = navItem?.color || ''
+  const bgClass = colorClasses.split(' ').find(c => c.startsWith('bg-')) || 'bg-gray-500'
+
+  return (
+    <div className={`${bgClass} text-white text-center py-4 mb-8`}>
+      <h1 className="text-3xl font-bold mb-2">{title}</h1>
+      {description && <p className="text-child-friendly">{description}</p>}
+    </div>
+  )
+}
+
+export default PageHeader

--- a/src/pages/CalculationPage.tsx
+++ b/src/pages/CalculationPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import BottomNavigation from '../components/common/BottomNavigation'
+import PageHeader from '../components/common/PageHeader'
 
 /**
  * おこづかい計算ページ（シンプル版）
@@ -173,51 +174,48 @@ const CalculationPage: React.FC = () => {
   return (
     <>
       <div className="max-w-4xl mx-auto pb-24">
-      <div className="text-center mb-8">
-        <h1 className="text-3xl font-bold text-gray-800 mb-2">
-          おこづかい計算
-        </h1>
-        <p className="text-gray-600">
-          今日やったタスクからおこづかいを計算しよう
-        </p>
-        <div className="flex justify-center items-center mt-4">
-          <div className="text-lg font-medium text-blue-600">
-            {new Date(selectedDate).toLocaleDateString('ja-JP', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-              weekday: 'long'
-            })}
-          </div>
-          <button
-            onClick={() => dateInputRef.current?.showPicker()}
-            className="ml-2 text-blue-600 hover:text-blue-800"
-            aria-label="日付を選択"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-              />
-            </svg>
-          </button>
-          <input
-            ref={dateInputRef}
-            type="date"
-            value={selectedDate}
-            onChange={handleDateChange}
-            className="hidden"
-          />
-          <button
-            onClick={handleCalculate}
-            disabled={!selectedDate || isLoading}
-            className="ml-4 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white px-6 py-2 rounded-md font-medium"
-          >
-            {isLoading ? '計算中...' : '計算する'}
-          </button>
+      <PageHeader
+        title="おこづかい計算"
+        description="今日やったタスクからおこづかいを計算しよう"
+        navId="calculation"
+      />
+      <div className="flex justify-center items-center mb-8">
+        <div className="text-lg font-medium text-blue-600">
+          {new Date(selectedDate).toLocaleDateString('ja-JP', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            weekday: 'long'
+          })}
         </div>
+        <button
+          onClick={() => dateInputRef.current?.showPicker()}
+          className="ml-2 text-blue-600 hover:text-blue-800"
+          aria-label="日付を選択"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+            />
+          </svg>
+        </button>
+        <input
+          ref={dateInputRef}
+          type="date"
+          value={selectedDate}
+          onChange={handleDateChange}
+          className="hidden"
+        />
+        <button
+          onClick={handleCalculate}
+          disabled={!selectedDate || isLoading}
+          className="ml-4 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white px-6 py-2 rounded-md font-medium"
+        >
+          {isLoading ? '計算中...' : '計算する'}
+        </button>
       </div>
       
       {/* ローディング表示 */}

--- a/src/pages/CategoryManagementPage.tsx
+++ b/src/pages/CategoryManagementPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { Category } from '../types'
 import TaskValidator from '../utils/taskValidation'
 import BottomNavigation from '../components/common/BottomNavigation'
+import PageHeader from '../components/common/PageHeader'
 
 const CategoryManagementPage: React.FC = () => {
   const [categories, setCategories] = useState<Category[]>([])
@@ -120,11 +121,7 @@ const CategoryManagementPage: React.FC = () => {
   if (error) {
     return (
         <div className="max-w-4xl mx-auto pb-24">
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-800 mb-2">
-            カテゴリ管理
-          </h1>
-        </div>
+        <PageHeader title="カテゴリ管理" navId="category-management" />
         
         <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
           <div className="flex items-center">
@@ -224,14 +221,11 @@ const CategoryManagementPage: React.FC = () => {
       )}
 
       <div className="max-w-4xl mx-auto pb-24">
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-800 mb-2">
-            カテゴリ管理
-          </h1>
-          <p className="text-gray-600">
-            タスクの種類を整理・管理できます
-          </p>
-        </div>
+        <PageHeader
+          title="カテゴリ管理"
+          description="タスクの種類を整理・管理できます"
+          navId="category-management"
+        />
 
         <div className="bg-white rounded-lg shadow-md p-6 mb-6">
           <div className="flex items-center justify-between mb-4">

--- a/src/pages/DailyInputPage.tsx
+++ b/src/pages/DailyInputPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import BottomNavigation from '../components/common/BottomNavigation'
+import PageHeader from '../components/common/PageHeader'
 import { Task, Category } from '../types'
 import {
   validateDailyInput,
@@ -212,11 +213,7 @@ const DailyInputPage: React.FC = () => {
   if (error) {
     return (
       <div className="max-w-4xl mx-auto">
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-800 mb-2">
-            タスク入力
-          </h1>
-        </div>
+        <PageHeader title="タスク入力" navId="daily-input" />
         
         <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
           <div className="flex items-center">
@@ -243,11 +240,7 @@ const DailyInputPage: React.FC = () => {
   if (categories.length === 0) {
     return (
       <div className="max-w-4xl mx-auto">
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-800 mb-2">
-            タスク入力
-          </h1>
-        </div>
+        <PageHeader title="タスク入力" navId="daily-input" />
         
         <div className="bg-white rounded-lg shadow-md p-12 text-center">
           <div className="text-6xl mb-4">📝</div>
@@ -278,44 +271,41 @@ const DailyInputPage: React.FC = () => {
     <>
       <div className="max-w-6xl mx-auto pb-24">
       {/* ヘッダー */}
-      <div className="text-center mb-8">
-        <h1 className="text-3xl font-bold text-gray-800 mb-2">
-          タスク入力
-        </h1>
-        <p className="text-gray-600 mb-4">
-          やったお手伝いや宿題を記録しよう
-        </p>
-        <div className="flex justify-center items-center mb-2">
-          <div className="text-lg font-medium text-blue-600">
-            {new Date(selectedDate).toLocaleDateString('ja-JP', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-              weekday: 'long'
-            })}
-          </div>
-          <button
-            onClick={() => dateInputRef.current?.showPicker()}
-            className="ml-2 text-blue-600 hover:text-blue-800"
-            aria-label="日付を選択"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-              />
-            </svg>
-          </button>
-          <input
-            ref={dateInputRef}
-            type="date"
-            value={selectedDate}
-            onChange={e => setSelectedDate(e.target.value)}
-            className="hidden"
-          />
+      <PageHeader
+        title="タスク入力"
+        description="やったお手伝いや宿題を記録しよう"
+        navId="daily-input"
+      />
+      <div className="flex justify-center items-center mb-8">
+        <div className="text-lg font-medium text-blue-600">
+          {new Date(selectedDate).toLocaleDateString('ja-JP', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            weekday: 'long'
+          })}
         </div>
+        <button
+          onClick={() => dateInputRef.current?.showPicker()}
+          className="ml-2 text-blue-600 hover:text-blue-800"
+          aria-label="日付を選択"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+            />
+          </svg>
+        </button>
+        <input
+          ref={dateInputRef}
+          type="date"
+          value={selectedDate}
+          onChange={e => setSelectedDate(e.target.value)}
+          className="hidden"
+        />
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo } from 'react'
 import { electronAPI } from '../services/electronAPI'
 import { StatisticsData } from '../types'
 import BottomNavigation from '../components/common/BottomNavigation'
+import PageHeader from '../components/common/PageHeader'
 
 const HistoryPage: React.FC = () => {
   const today = new Date().toISOString().split('T')[0]
@@ -116,11 +117,12 @@ const HistoryPage: React.FC = () => {
   return (
     <>
       <div className="max-w-4xl mx-auto pb-24">
-      <div className="text-center mb-8">
-        <h1 className="text-3xl font-bold text-gray-800 mb-2">履歴を見る</h1>
-        <p className="text-child-friendly text-gray-600 mb-2">過去のおこづかい記録を確認しよう</p>
-        <p className="text-red-500">この画面は現在工事中です</p>
-      </div>
+      <PageHeader
+        title="履歴を見る"
+        description="過去のおこづかい記録を確認しよう"
+        navId="history"
+      />
+      <p className="text-red-500 text-center mb-8">この画面は現在工事中です</p>
 
       <form onSubmit={handleSubmit} className="card mb-6">
         <div className="flex flex-col md:flex-row gap-4 items-end">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,21 +1,21 @@
 import React from 'react'
 import Navigation from '../components/common/Navigation'
 import WelcomeMessage from '../components/common/WelcomeMessage'
+import PageHeader from '../components/common/PageHeader'
 
 const HomePage: React.FC = () => {
   return (
     <>
       <WelcomeMessage />
       <div className="max-w-4xl mx-auto">
-        <div className="text-center mb-8 animate-fade-in">
-          <h1 className="text-4xl font-bold text-gray-800 mb-2">
-            おこづかい請求アプリ
-          </h1>
-          <p className="text-child-friendly text-gray-600">
-            毎日のお手伝いや宿題を記録して、おこづかいを計算しよう！
-          </p>
+        <div className="animate-fade-in">
+          <PageHeader
+            title="おこづかい請求アプリ"
+            description="毎日のお手伝いや宿題を記録して、おこづかいを計算しよう！"
+            navId="home"
+          />
         </div>
-        
+
         <div className="animate-slide-in-up">
           <Navigation />
         </div>

--- a/src/pages/TaskManagementPage.tsx
+++ b/src/pages/TaskManagementPage.tsx
@@ -5,6 +5,7 @@ import TaskValidator from '../utils/taskValidation'
 import ConfirmDialog from '../components/common/ConfirmDialog'
 import Alert from '../components/common/Alert'
 import BottomNavigation from '../components/common/BottomNavigation'
+import PageHeader from '../components/common/PageHeader'
 
 const TaskManagementPage: React.FC = () => {
   const [tasks, setTasks] = useState<Task[]>([])
@@ -182,9 +183,7 @@ const TaskManagementPage: React.FC = () => {
   if (error) {
     return (
       <div className="max-w-4xl mx-auto">
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-800 mb-2">タスク管理</h1>
-        </div>
+        <PageHeader title="タスク管理" navId="task-management" />
         <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
           <div className="flex items-center">
             <span className="text-red-600 text-xl mr-2">⚠️</span>
@@ -311,10 +310,11 @@ const TaskManagementPage: React.FC = () => {
       )}
 
       <div className="max-w-6xl mx-auto pb-24">
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-800 mb-2">タスク管理</h1>
-          <p className="text-gray-600">お手伝いや宿題を登録・編集できます</p>
-        </div>
+        <PageHeader
+          title="タスク管理"
+          description="お手伝いや宿題を登録・編集できます"
+          navId="task-management"
+        />
 
         {notification && (
           <div className="mb-4">


### PR DESCRIPTION
## Summary
- create PageHeader component that styles captions using navigation colors
- replace individual page headers with PageHeader across app pages

## Testing
- `npm run lint` *(fails: ESLint couldn't find the config "@typescript-eslint/recommended")*


------
https://chatgpt.com/codex/tasks/task_e_68aa85959c3c832094849ccba72b3d4b